### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR so the project can be used as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.7)
 
 enable_testing()
 
-include_directories(${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 if (DEFINED NDEBUG)
     add_definitions(-DNDEBUG=1)


### PR DESCRIPTION
Currently using CMAKE_SOURCE_DIR the project will fail to compile if used as a sub-module to another project. CMAKE_CURRENT_SOURCE_DIR remedies this.