### PR TITLE
remove unnecessary include directive

### DIFF
--- a/bluetoe/bindings/nrf51/nrf51.cpp
+++ b/bluetoe/bindings/nrf51/nrf51.cpp
@@ -1,7 +1,6 @@
 #include <bluetoe/nrf51.hpp>
 
 #include <nrf.h>
-#include <core_cmInstr.h>
 
 #include <cassert>
 #include <cstdint>


### PR DESCRIPTION
This allows compilation with a wider range of nordic sdks that
no longer have core_cmInstr.h