### PR TITLE
remove warnings from building the examples

### DIFF
--- a/bluetoe/bindings/nordic/nrf52/security_tool_box.cpp
+++ b/bluetoe/bindings/nordic/nrf52/security_tool_box.cpp
@@ -93,9 +93,9 @@ namespace nrf52_details
             a.begin(), a.end(),
             b,
             a.begin(),
-            []( std::uint8_t a, std::uint8_t b ) -> std::uint8_t
+            []( std::uint8_t x, std::uint8_t y ) -> std::uint8_t
             {
-                return a xor b;
+                return x xor y;
             }
         );
 
@@ -203,6 +203,8 @@ namespace nrf52_details
         assert( rc == 1 );
 
         bluetoe::details::ecdh_shared_secret_t result;
+        static_assert(shared_secret.size() == result.size(), "");
+
         std::reverse_copy( shared_secret.begin(), shared_secret.end(), result.begin() );
 
         return result;
@@ -211,6 +213,8 @@ namespace nrf52_details
     static bluetoe::details::uint128_t left_shift(const bluetoe::details::uint128_t& input)
     {
         bluetoe::details::uint128_t output;
+
+        static_assert(input.size() == output.size(), "");
 
         std::uint8_t overflow = 0;
         for ( std::size_t i = 0; i != input.size(); ++i )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -59,7 +59,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/.. ${CMAKE_CURRENT_BINARY_DIR}/blue
 target_link_libraries(bluetoe_iface INTERFACE assert::arm)
 
 function(add_bluetoe_example target_name)
-    add_executable(${target_name} ${target_name}.cpp runtime.cpp)
+    add_executable(${target_name} ${target_name}.cpp runtime_gcc.cpp)
     set_target_properties(${target_name}
         PROPERTIES
             OUTPUT_NAME ${target_name}.elf)

--- a/examples/runtime_gcc.cpp
+++ b/examples/runtime_gcc.cpp
@@ -27,7 +27,13 @@ extern "C" void _start(void) {
     for ( vector* init = &__init_array_start[ 0 ]; init != &__init_array_end[ 0 ]; ++init )
         (*init)();
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+// ISO C++ forbids calling main. We are silencing this warning explicitly.
+// This startup code replaces the one provided by newlib, which is not being used in
+// order to save space from the final binary.
     main();
+#pragma GCC diagnostic pop
 
     for ( vector* finit = &__fini_array_start[ 0 ]; finit != &__fini_array_end[ 0 ]; ++finit )
         (*finit)();


### PR DESCRIPTION
These commits do not change the behaviour or the binary, they intend to add readability and remove warnings.