### PR TITLE
fix build errors with arm gcc 10.3

### DIFF
--- a/bluetoe/bindings/nordic/nrf52/security_tool_box.cpp
+++ b/bluetoe/bindings/nordic/nrf52/security_tool_box.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <bluetoe/security_tool_box.hpp>
 #include <bluetoe/nrf.hpp>
 
@@ -214,7 +215,7 @@ namespace nrf52_details
     {
         bluetoe::details::uint128_t output;
 
-        static_assert(input.size() == output.size(), "");
+        assert(input.size() == output.size());
 
         std::uint8_t overflow = 0;
         for ( std::size_t i = 0; i != input.size(); ++i )

--- a/examples/synchronized_callbacks.cpp
+++ b/examples/synchronized_callbacks.cpp
@@ -88,7 +88,7 @@ device<
     blinky_server,
     link_layer::buffer_sizes< 200, 200 >,
     bluetoe::link_layer::synchronized_connection_event_callback<
-        callback_handler_t, callback_handler, 4000u, -1000u, 20u >,
+        callback_handler_t, callback_handler, 4000u, -1000, 20u >,
     bluetoe::link_layer::check_synchronized_connection_event_callback
 > gatt_srv;
 


### PR DESCRIPTION
Arm gcc complains about array.size() not being constexpr. This was not present with previous gcc versions. As a safe behaviour, transform the static_assert into a runtime assert.

Fix synchronised callbacks error due to narrowing conversion.