### PR TITLE
container, add minimal support to build the examples

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,17 @@
+FROM frolvlad/alpine-glibc as base
+
+RUN  apk update \
+     && apk add --no-cache --update git tar wget ncurses libusb unzip ninja cmake make \
+     && rm /lib64/ld-linux-x86-64.so.2 \
+     && ln -s /usr/glibc-compat/lib/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2
+
+RUN mkdir -p /opt/ && cd /opt &&  \
+    wget -q https://www.nordicsemi.com/-/media/Software-and-other-downloads/SDKs/nRF5/Binaries/nRF5_SDK_17.1.0_ddde560.zip \
+        && unzip -q nRF5_SDK_17.1.0_ddde560.zip "nRF5_SDK_17.1.0_ddde560/components/toolchain/cmsis/include/*" \
+           "nRF5_SDK_17.1.0_ddde560/modules/*" -d . \
+        && mv nRF5_SDK_17.1.0_ddde560 nrf5_sdk \
+        && rm nRF5_SDK_17.1.0_ddde560.zip
+
+RUN wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -P /usr/local \
+        && tar -C /usr/local -xf /usr/local/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 --no-same-owner \
+        && rm /usr/local/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2

--- a/examples/docker/Makefile
+++ b/examples/docker/Makefile
@@ -1,0 +1,71 @@
+# Container engine to be used (typically: podman|docker)
+CONTAINER_ENGINE := docker
+
+# Name of the container image
+CONTAINER_IMAGE ?= bluetoe_alpine
+
+# Mount point where the quark-derived project will exist within the container
+CONTAINER_TARGET := /work
+
+COMMAND ?= mkdir -p ../build && cd ../build && cmake -GNinja -DARM_GCC_TOOL_PATH=/usr/local/gcc-arm-none-eabi-10.3-2021.10/ -DNRF5_SDK_ROOT=/opt/nrf5_sdk/ -DCMAKE_TOOLCHAIN_FILE=../cmake/gcc-arm-none-eabi.cmake .. && ninja
+
+.PHONY: all
+all: container-build
+
+.PHONY: clean
+clean:
+	rm -rf ../build
+
+.PHONY: container-build-image
+container-build-image:
+	@image_sha=`$(CONTAINER_ENGINE) images -q $(CONTAINER_IMAGE)`;\
+	if [ -z "$$image_sha" ];\
+    then\
+    echo "Building $(CONTAINER_IMAGE). This will take a few minutes...";\
+	$(CONTAINER_ENGINE) build --rm --tag $(CONTAINER_IMAGE) .;\
+	else\
+    echo "Using existing image $(CONTAINER_IMAGE)-> $$image_sha ";\
+	fi
+
+# If there is no local image with the required image name, the recipe tries to pull
+# the image from a container registry.
+.PHONY: container-pull-image
+container-pull-image:
+	@image_sha=`$(CONTAINER_ENGINE) images -q $(CONTAINER_IMAGE)`;\
+	if [ -z "$$image_sha" ];\
+    then\
+    echo "Did not find a local container image with name:$(CONTAINER_IMAGE). Fetching one from the container registry...";\
+	$(CONTAINER_ENGINE) pull $(CONTAINER_IMAGE);\
+	else\
+    echo "Using existing local image $(CONTAINER_IMAGE)-> $$image_sha ";\
+	fi
+
+.PHONY: container-shell
+container-shell: container-build-image
+	@$(CONTAINER_ENGINE) run --rm -ti \
+	--user=$(shell id -u):$(shell id -g) \
+	--mount type="bind,src=$(PWD)/../..,target=$(CONTAINER_TARGET)" \
+	--workdir="$(CONTAINER_TARGET)" $(CONTAINER_IMAGE)
+
+.PHONY: container-build
+container-build: container-build-image
+	$(CONTAINER_ENGINE) run --rm -ti \
+	--user=$(shell id -u):$(shell id -g) \
+	--mount type="bind,src=$(PWD)/../..,target=$(CONTAINER_TARGET)" \
+	--workdir="$(CONTAINER_TARGET)/examples/docker" \
+	$(CONTAINER_IMAGE) sh -c "$(COMMAND)"
+
+.PHONY: container-delete
+container-delete:
+	@$(CONTAINER_ENGINE) rmi $(CONTAINER_IMAGE)
+
+.PHONY: help
+help:
+	@echo "Supported targets:"
+	@echo "  all                     Executes the ./buildAll.sh script inside the container"
+	@echo "  container-build-image   Builds the $(CONTAINER_IMAGE) image based on the Dockerfile"
+	@echo "  container-pull-image    Fetches the $(CONTAINER_IMAGE) image from the container registry"
+	@echo "  container-shell         Opens a shell in a temporary container"
+	@echo "  container-build         Executes COMMAND inside a temporary container"
+	@echo "  container-delete        Deletes the $(CONTAINER_IMAGE) image"
+	@echo "  help                    You're looking at it"


### PR DESCRIPTION
Once docker or podman are installed on the host, it is possible to build all the examples by executing 'make' on the bluetoe/examples/docker folder.

Fixes https://github.com/TorstenRobitzki/bluetoe/issues/93