### PR TITLE
copy only the announced number of bytes into the L2CAP receive buffer (#137)

### DIFF
--- a/bluetoe/link_layer/include/bluetoe/ll_l2cap_sdu_buffer.hpp
+++ b/bluetoe/link_layer/include/bluetoe/ll_l2cap_sdu_buffer.hpp
@@ -243,7 +243,7 @@ namespace link_layer {
     {
         const std::size_t copy_size = std::min< std::size_t >( receive_size_, end - begin );
 
-        std::copy( begin, end, &receive_buffer_[ receive_buffer_used_ ] );
+        std::copy( begin, begin + copy_size, &receive_buffer_[ receive_buffer_used_ ] );
         receive_buffer_used_ += copy_size;
         receive_size_ -= copy_size;
     }

--- a/tests/link_layer/ll_l2cap_sdu_buffer_tests.cpp
+++ b/tests/link_layer/ll_l2cap_sdu_buffer_tests.cpp
@@ -6,6 +6,7 @@
 #include "test_layout.hpp"
 
 #include <initializer_list>
+#include <vector>
 
 using namespace boost::test_tools;
 
@@ -67,6 +68,11 @@ namespace {
             received_pdus_.push_back( pdu_t{ incomming_pdu.begin(), incomming_pdu.end() } );
         }
 
+        void add_received_pdu( const std::vector< std::uint8_t >& incomming_pdu )
+        {
+            received_pdus_.push_back( incomming_pdu );
+        }
+
         bool receive_buffer_empty() const
         {
             return received_pdus_.empty();
@@ -113,7 +119,9 @@ namespace {
         std::vector< pdu_t > received_data_pdus_;
     };
 
-    class buffer_under_test : public bluetoe::link_layer::ll_l2cap_sdu_buffer< radio_mock_t, radio_mock_t, 100 >
+    static constexpr std::size_t mtu_size = 100;
+
+    class buffer_under_test : public bluetoe::link_layer::ll_l2cap_sdu_buffer< radio_mock_t, radio_mock_t, mtu_size >
     {
     public:
         void expect_next_received( std::initializer_list< std::uint8_t > expected )
@@ -359,6 +367,95 @@ BOOST_AUTO_TEST_SUITE( receive_buffer_for_mtu_size_larger_than_23_bytes )
 
         expect_next_received( {} );
 
+    }
+
+    /*
+     * Fixture to receive an SDU that uses the maximum MTU size. The receive buffer is
+     * dimensioned to hold exactly such an SDU, including the L2CAP header and the link
+     * layer header of the first fragment.
+     */
+    struct maximum_sized_sdu : buffer_under_test
+    {
+        static constexpr std::size_t ll_header_size    = 3;     // header + layout overhead
+        static constexpr std::size_t l2cap_header_size = 4;
+
+        // start fragment, announcing an SDU of mtu_size bytes and containing the first
+        // data_size bytes of that SDU
+        void add_start_fragment( std::size_t data_size, std::uint8_t fill )
+        {
+            std::vector< std::uint8_t > pdu = {
+                0x02, static_cast< std::uint8_t >( l2cap_header_size + data_size ), 0xaa,
+                static_cast< std::uint8_t >( mtu_size ), 0x00,  // L2CAP length
+                0x04, 0x00                                      // channel id
+            };
+
+            pdu.insert( pdu.end(), data_size, fill );
+            add_received_pdu( pdu );
+        }
+
+        void add_continuation_fragment( std::size_t data_size, std::uint8_t fill )
+        {
+            std::vector< std::uint8_t > pdu = {
+                0x01, static_cast< std::uint8_t >( data_size ), 0xaa
+            };
+
+            pdu.insert( pdu.end(), data_size, fill );
+            add_received_pdu( pdu );
+        }
+    };
+
+    /*
+     * A peer that announces an SDU and then sends more data than announced, must not be
+     * able to have that data written beyond the end of the receive buffer (#137).
+     */
+    BOOST_FIXTURE_TEST_CASE( continuation_fragment_larger_than_the_rest_of_the_sdu, maximum_sized_sdu )
+    {
+        // 23 + 27 + 27 + 20 == 97 out of the announced 100 bytes
+        add_start_fragment( 23, 0x01 );
+        add_continuation_fragment( 27, 0x02 );
+        add_continuation_fragment( 27, 0x03 );
+        add_continuation_fragment( 20, 0x04 );
+
+        // 3 bytes are missing, but the peer sends a full sized fragment
+        add_continuation_fragment( 27, 0xff );
+
+        std::vector< std::uint8_t > expected = {
+            0x02, 0x1b, 0xaa,   // link layer header of the first fragment
+            0x64, 0x00,         // L2CAP length: 100
+            0x04, 0x00          // channel id
+        };
+
+        expected.insert( expected.end(), 23, 0x01 );
+        expected.insert( expected.end(), 27, 0x02 );
+        expected.insert( expected.end(), 27, 0x03 );
+        expected.insert( expected.end(), 20, 0x04 );
+        expected.insert( expected.end(),  3, 0xff );    // only the 3 announced bytes are used
+
+        const auto received = next_ll_l2cap_received();
+
+        BOOST_REQUIRE_EQUAL( received.size, expected.size() );
+        BOOST_CHECK_EQUAL_COLLECTIONS(
+            received.buffer, received.buffer + received.size,
+            expected.begin(), expected.end() );
+    }
+
+    BOOST_FIXTURE_TEST_CASE( receiving_after_a_too_large_continuation_fragment, maximum_sized_sdu )
+    {
+        add_start_fragment( 23, 0x01 );
+        add_continuation_fragment( 27, 0x02 );
+        add_continuation_fragment( 27, 0x03 );
+        add_continuation_fragment( 20, 0x04 );
+        add_continuation_fragment( 27, 0xff );
+
+        // a link layer control PDU, following the malformed SDU
+        add_received_pdu( { 0x03, 0x03, 0xaa, 0x01, 0x02, 0x03 } );
+
+        const std::size_t sdu_size = ll_header_size + l2cap_header_size + mtu_size;
+
+        BOOST_REQUIRE_EQUAL( next_ll_l2cap_received().size, sdu_size );
+        free_ll_l2cap_received();
+
+        expect_next_received( { 0x03, 0x03, 0xaa, 0x01, 0x02, 0x03 } );
     }
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Fixes #137.

## The bug

`ll_l2cap_sdu_buffer::add_to_receive_buffer()` clamped the bookkeeping to the number of bytes that
still fit into the reassembly buffer, but copied the whole fragment:

```cpp
const std::size_t copy_size = std::min< std::size_t >( receive_size_, end - begin );

std::copy( begin, end, &receive_buffer_[ receive_buffer_used_ ] );  // end, not begin + copy_size
receive_buffer_used_ += copy_size;
receive_size_ -= copy_size;
```

A connected central can trigger this over the air: it announces an L2CAP SDU of `MTUSize` bytes,
sends continuation fragments until only a few bytes are missing, and then sends one more full sized
fragment. The write then runs past the end of `receive_buffer_`.

The same one line is also used for the start fragment, where a peer can announce a small L2CAP
length and send a first fragment that is larger than the announced SDU. That path can only overflow
when `MTUSize` is small; it is fixed by the same change.

The sibling code in `try_send_pdus()` uses `copy_size` correctly in both of its branches, so this
reads as a slip rather than a misunderstanding.

## Impact

The overflow is bounded by one link layer payload (27 bytes without data length extension), so it
does not leave the object. With `MTUSize` of 100 and the layout used in the unit tests, the write
covers the object's offsets 104 to 130, while `receive_buffer_` ends at 106:

| member | offset |
|---|---|
| `receive_buffer_` | 0 .. 106 |
| `receive_size_` | 108 |
| `receive_buffer_used_` | 112 |
| `transmit_buffer_` | 120 |

So the peer overwrites `receive_size_`, `receive_buffer_used_` and the beginning of
`transmit_buffer_` with data of its choosing. Because `receive_buffer_used_` is the offset used by
the *next* fragment, a second fragment is then written to an attacker influenced address, which is
no longer bounded by the object.

## Why the tests do not trigger AddressSanitizer

I tried to write a test that makes the sanitizer report the overflow, and could not, for a reason
worth recording: AddressSanitizer places its red zones around whole allocations, not between the
members of an object. As shown above, the write stays inside the object, so ASan has nothing to
report. Clang can instrument members with `-fsanitize-address-field-padding=1`, but that changes
the layout of every class and fails to link against a standard library that was not built with the
same flag, so it is not usable here.

The two new tests therefore detect the corruption through observable behaviour instead, which works
in every build and needs no sanitizer:

- `continuation_fragment_larger_than_the_rest_of_the_sdu` checks that the SDU is delivered with the
  announced size and content. Before the fix, the overflow overwrites `receive_size_` with `0xffff`,
  so the SDU is never considered complete and the buffer returns nothing.
- `receiving_after_a_too_large_continuation_fragment` checks that the buffer still works afterwards.
  Before the fix, the following link layer control PDU is returned in place of the SDU.

Both fail against the unfixed code:

```
fatal error: ... critical check received.size == expected.size() has failed [0 != 107]
fatal error: ... critical check next_ll_l2cap_received().size == sdu_size has failed [6 != 107]
```

## The fix

Copy only the bytes that were accounted for. A peer that sends more data than it announced now has
the surplus ignored, and the SDU is delivered with exactly the announced length.

Discarding the whole SDU as a protocol error would be the stricter alternative. I kept the change
minimal because the surrounding code already computes the truncation, and dropping the SDU would
change behaviour for cases beyond the malformed one.

## Verification

- Debug and Release on macOS, 76 of 76 test executables pass.
- The two new tests fail before the fix and pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
