### PR TITLE
nrf52: make the wake up counter atomic (#138)

### DIFF
--- a/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
+++ b/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
@@ -8,8 +8,6 @@
 #include <bluetoe/security_tool_box.hpp>
 #include <bluetoe/connection_events.hpp>
 
-#include <atomic>
-
 /**
  * @file nrf52.hpp
  *
@@ -241,7 +239,7 @@ namespace bluetoe
             // if between setting up a user timer and calling the corresponding callback,
             // the anchor moved, inform the callback, so that the callback can schedule
             // the next call to the new anchor
-            static std::atomic< bool > user_timer_anchor_moved_;
+            volatile static bool user_timer_anchor_moved_;
         };
 
         /**
@@ -306,8 +304,8 @@ namespace bluetoe
             static bool resolving_address_invalid();
 
         private:
-            static std::atomic< bool >  receive_encrypted_;
-            static std::atomic< bool >  transmit_encrypted_;
+            static volatile bool    receive_encrypted_;
+            static volatile bool    transmit_encrypted_;
             static std::uint8_t*    encrypted_area_;
             static counter          receive_counter_;
             static counter          transmit_counter_;
@@ -529,13 +527,13 @@ namespace bluetoe
 
                 if ( wake_up_ )
                 {
-                    --wake_up_;
+                    __atomic_fetch_sub( &wake_up_, 1, __ATOMIC_RELAXED );
                 }
             }
 
             void wake_up()
             {
-                ++wake_up_;
+                __atomic_fetch_add( &wake_up_, 1, __ATOMIC_RELAXED );
             }
 
             void request_event_cancelation()
@@ -779,12 +777,12 @@ namespace bluetoe
                 return static_cast< const CallBacks* >( this )->is_scan_request_in_filter( scanner );
             }
 
-            std::atomic< bool > adv_timeout_{ false };
-            std::atomic< bool > adv_received_{ false };
-            std::atomic< bool > evt_timeout_{ false };
-            std::atomic< bool > end_evt_{ false };
-            std::atomic< bool > request_event_cancelation_{ false };
-            std::atomic< int > wake_up_{ 0 };
+            volatile bool adv_timeout_;
+            volatile bool adv_received_;
+            volatile bool evt_timeout_;
+            volatile bool end_evt_;
+            volatile bool request_event_cancelation_;
+            volatile int  wake_up_;
 
             enum class state {
                 idle,

--- a/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
+++ b/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
@@ -241,7 +241,7 @@ namespace bluetoe
             // if between setting up a user timer and calling the corresponding callback,
             // the anchor moved, inform the callback, so that the callback can schedule
             // the next call to the new anchor
-            volatile static bool user_timer_anchor_moved_;
+            static std::atomic< bool > user_timer_anchor_moved_;
         };
 
         /**
@@ -306,8 +306,8 @@ namespace bluetoe
             static bool resolving_address_invalid();
 
         private:
-            static volatile bool    receive_encrypted_;
-            static volatile bool    transmit_encrypted_;
+            static std::atomic< bool >  receive_encrypted_;
+            static std::atomic< bool >  transmit_encrypted_;
             static std::uint8_t*    encrypted_area_;
             static counter          receive_counter_;
             static counter          transmit_counter_;
@@ -779,11 +779,11 @@ namespace bluetoe
                 return static_cast< const CallBacks* >( this )->is_scan_request_in_filter( scanner );
             }
 
-            volatile bool adv_timeout_;
-            volatile bool adv_received_;
-            volatile bool evt_timeout_;
-            volatile bool end_evt_;
-            volatile bool request_event_cancelation_;
+            std::atomic< bool > adv_timeout_{ false };
+            std::atomic< bool > adv_received_{ false };
+            std::atomic< bool > evt_timeout_{ false };
+            std::atomic< bool > end_evt_{ false };
+            std::atomic< bool > request_event_cancelation_{ false };
             std::atomic< int > wake_up_{ 0 };
 
             enum class state {

--- a/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
+++ b/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
@@ -8,6 +8,8 @@
 #include <bluetoe/security_tool_box.hpp>
 #include <bluetoe/connection_events.hpp>
 
+#include <atomic>
+
 /**
  * @file nrf52.hpp
  *
@@ -782,7 +784,11 @@ namespace bluetoe
             volatile bool evt_timeout_;
             volatile bool end_evt_;
             volatile bool request_event_cancelation_;
-            volatile int  wake_up_;
+
+            // Unlike the flags above, which are set in one context and cleared in the other,
+            // this counter is incremented by wake_up() and decremented by run(). A volatile
+            // read-modify-write is not atomic, so an increment from an interrupt could be lost.
+            std::atomic< int > wake_up_{ 0 };
 
             enum class state {
                 idle,

--- a/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
+++ b/bluetoe/bindings/nordic/nrf52/include/bluetoe/nrf52.hpp
@@ -784,10 +784,6 @@ namespace bluetoe
             volatile bool evt_timeout_;
             volatile bool end_evt_;
             volatile bool request_event_cancelation_;
-
-            // Unlike the flags above, which are set in one context and cleared in the other,
-            // this counter is incremented by wake_up() and decremented by run(). A volatile
-            // read-modify-write is not atomic, so an increment from an interrupt could be lost.
             std::atomic< int > wake_up_{ 0 };
 
             enum class state {

--- a/bluetoe/bindings/nordic/nrf52/nrf52.cpp
+++ b/bluetoe/bindings/nordic/nrf52/nrf52.cpp
@@ -4,7 +4,6 @@
 
 #include <cstring>
 #include <algorithm>
-#include <atomic>
 
 namespace bluetoe
 {
@@ -812,7 +811,7 @@ namespace nrf52_details
     bool                   radio_hardware_without_crypto_support::transmit_2mbit_;
     volatile int           radio_hardware_without_crypto_support::hf_connection_event_anchor_;
     volatile std::uint32_t radio_hardware_without_crypto_support::lf_connection_event_anchor_;
-    std::atomic< bool >    radio_hardware_without_crypto_support::user_timer_anchor_moved_{ false };
+    volatile bool          radio_hardware_without_crypto_support::user_timer_anchor_moved_;
 
     //////////////////////////////////////////////
     // class radio_hardware_with_crypto_support
@@ -1124,8 +1123,8 @@ namespace nrf52_details
         return false;
     }
 
-    std::atomic< bool > radio_hardware_with_crypto_support::receive_encrypted_{ false };
-    std::atomic< bool > radio_hardware_with_crypto_support::transmit_encrypted_{ false };
+    volatile bool radio_hardware_with_crypto_support::receive_encrypted_  = false;
+    volatile bool radio_hardware_with_crypto_support::transmit_encrypted_ = false;
     std::uint8_t* radio_hardware_with_crypto_support::encrypted_area_;
     counter radio_hardware_with_crypto_support::transmit_counter_;
     counter radio_hardware_with_crypto_support::receive_counter_;

--- a/bluetoe/bindings/nordic/nrf52/nrf52.cpp
+++ b/bluetoe/bindings/nordic/nrf52/nrf52.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <algorithm>
+#include <atomic>
 
 namespace bluetoe
 {
@@ -811,7 +812,7 @@ namespace nrf52_details
     bool                   radio_hardware_without_crypto_support::transmit_2mbit_;
     volatile int           radio_hardware_without_crypto_support::hf_connection_event_anchor_;
     volatile std::uint32_t radio_hardware_without_crypto_support::lf_connection_event_anchor_;
-    volatile bool          radio_hardware_without_crypto_support::user_timer_anchor_moved_;
+    std::atomic< bool >    radio_hardware_without_crypto_support::user_timer_anchor_moved_{ false };
 
     //////////////////////////////////////////////
     // class radio_hardware_with_crypto_support
@@ -1123,8 +1124,8 @@ namespace nrf52_details
         return false;
     }
 
-    volatile bool radio_hardware_with_crypto_support::receive_encrypted_  = false;
-    volatile bool radio_hardware_with_crypto_support::transmit_encrypted_ = false;
+    std::atomic< bool > radio_hardware_with_crypto_support::receive_encrypted_{ false };
+    std::atomic< bool > radio_hardware_with_crypto_support::transmit_encrypted_{ false };
     std::uint8_t* radio_hardware_with_crypto_support::encrypted_area_;
     counter radio_hardware_with_crypto_support::transmit_counter_;
     counter radio_hardware_with_crypto_support::receive_counter_;


### PR DESCRIPTION
Fixes #138.

## The bug

`wake_up_` is incremented by `wake_up()` and decremented by `run()`:

```cpp
if ( wake_up_ )
{
    --wake_up_;
}

void wake_up()
{
    ++wake_up_;
}
```

Both are read-modify-write sequences. `volatile` forces the compiler to emit the load and the
store, but it does not make the pair atomic. When an interrupt calls `wake_up()` between the load
and the store of `--wake_up_`, the increment is lost and the pending work waits until the next
radio event wakes the main loop.

`wake_up()` is reachable from interrupt context: the connection callbacks call it, and the
application may call it from its own ISR, which is what the GPIO driven examples do.

## The fix

```cpp
__atomic_fetch_sub( &wake_up_, 1, __ATOMIC_RELAXED );
...
__atomic_fetch_add( &wake_up_, 1, __ATOMIC_RELAXED );
```

`wake_up_` stays a `volatile int`. Only the two read-modify-write sites change, which is the only
place the race was. `run()` remains the only decrementer, so testing for a value greater than zero
and then decrementing stays correct even when an increment arrives in between, because the value
can only have grown.

Relaxed ordering is enough. An interrupt on a single core runs to completion before the main loop
resumes, so what was missing was the indivisibility of the update, not ordering against other
memory accesses.

The five `volatile bool` flags in the same class are left alone. A byte access is indivisible on
this core and each flag has one writer and one clearer, so `volatile` is already the right tool
there.

## Cost on the target

The builtins compile to an inlined retry loop, with no barrier, no call and no library
dependency, which matters because the firmware links with `-nostdlib`:

```
ldrex r1, [r3]
adds  r1, #1
strex r2, r1, [r3]
cmp   r2, #0
bne   retry
```

All twelve examples build and link for a PCA10040 with arm-none-eabi-gcc 14.2. Flash change
against master across those twelve, measured with the scripts the examples job uses, is between
-48 and +24 bytes; two examples shrink, so the real cost is around 16 bytes. RAM is unchanged.

For the record, this branch first used `std::atomic`, which cost far more:

| variant | Flash change |
|---|---|
| `std::atomic< int >` for the counter only | +20 to +68 |
| `std::atomic< int >` plus `std::atomic< bool >` for the eight flags | +192 to +296 |
| `__atomic` builtins on the counter, flags left `volatile` | -48 to +24 |

The barriers were not the main cost. A per symbol comparison showed the reads of the flags in
`run()` being emitted as calls to `std::atomic< bool >::operator bool()` rather than a single
`ldrb`; nine such calls landed in `main` alone. The same accessor inlines correctly in a minimal
file compiled with the same flags, so it is specific to the size of `run()` once inlined, but the
effect is reproducible at both `-Os` and `-O2` and survives raising the inliner's growth limits.

## Not covered here

`nrf51.hpp` has the same `volatile int wake_up_` with the same race. The nRF51 is a Cortex-M0 and
has no `ldrex`/`strex`, so the builtins would emit calls into `libatomic` there. The interrupt
disabling `lock_guard` that already exists in the binding is the fix for that part, and there is
no example target to build it with. Worth its own issue.

## Verification

- Twelve examples cross compiled and linked for Cortex-M4.
- Disassembly confirms an inlined `ldrex`/`strex` pair and no barriers anywhere in the image.
- Sizes measured against master.
- The host unit tests do not compile the Nordic bindings, so the examples job is the check that
  matters for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
