### PR TITLE
nrf51: guard the wake up counter with the lock_guard

### DIFF
--- a/bluetoe/bindings/nordic/nrf51/nrf51.cpp
+++ b/bluetoe/bindings/nordic/nrf51/nrf51.cpp
@@ -847,12 +847,16 @@ namespace nrf51_details {
 
         if ( wake_up_ )
         {
+            lock_guard lock;
+
             --wake_up_;
         }
     }
 
     void scheduled_radio_base::wake_up()
     {
+        lock_guard lock;
+
         ++wake_up_;
     }
 


### PR DESCRIPTION
The nRF51 binding has the same lost wake up as the nRF52 one in #142: `wake_up()` increments
`wake_up_` and `run()` decrements it, neither read-modify-write is atomic, and an increment
arriving from an interrupt between the load and the store of the decrement is lost.

The fix used for the nRF52 does not apply here. The Cortex-M0 has no `ldrex`/`strex`, so
`__atomic_fetch_add` would emit a call into `libatomic`, which the firmware does not link.
`lock_guard` saves `PRIMASK` and disables interrupts, is already used twice in this file, and is
the right tool on this core.

The guard is taken inside the `if`, so `run()` only masks interrupts when there is actually
something to decrement rather than on every pass of its loop. The test outside the guard stays
correct because `run()` is the only place that decrements, so once it has seen a value greater
than zero the value can only have grown.

## A finding that came out of verifying this

`nrf51.cpp` does not compile, and has not for some time. Against the nRF51 headers of nRF5 SDK 11,
the last SDK to support the part, it produces twelve errors, all of them uses of nRF52 only
registers and fields:

- `RADIO_PCNF0_S1INCL_Include`, `_Automatic` and `_Pos`
- `NRF_RADIO_Type::EVENTS_CRCERROR`
- `CCM_MODE_LENGTH_Extended` and `CCM_MODE_LENGTH_Pos`
- `NRF_GPIOTE_Type::TASKS_SET`

The CMake target is `EXCLUDE_FROM_ALL`, so nothing builds it and nothing noticed. I verified that
this change adds no new errors: the error sets before and after are identical, so the diff is as
verified as it can be until the binding compiles again.

Two things follow from that, neither of which belongs in this pull request. The binding is either
worth repairing or worth retiring, and whichever it is, the examples build has no nRF51
configuration, so CI cannot protect it either way. Happy to open an issue for that if you want one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
