### PR TITLE
state and check the contract of allocate_l2cap_output_buffer() (#139)

### DIFF
--- a/bluetoe/l2cap.hpp
+++ b/bluetoe/l2cap.hpp
@@ -84,10 +84,13 @@ namespace details {
      *
      * LinkLayer derives from l2cap<> and provides following functions:
      *
-     * - std::pair< std::size_t, std::uint8_t* > allocate_l2cap_output_buffer( std::size_t )
+     * - std::pair< std::size_t, std::uint8_t* > allocate_l2cap_output_buffer( std::size_t payload_size )
      *
      *   This function is used to allocate outgoing capacity. If the function can not provide
-     *   the requested size, it has to provide { 0, nullptr }.
+     *   the requested size, it has to provide { 0, nullptr }. Otherwise, the returned buffer
+     *   has to be large enough to take an L2CAP PDU with a payload of the requested size, so
+     *   that a returned size that is not zero is all the l2cap layer has to check. How much
+     *   room the link layer requires for its own purpose, is not visible to the l2cap layer.
      *
      * - void commit_l2cap_output_buffer( std::pair< std::size_t, std::uint8_t* > )
      *
@@ -233,6 +236,7 @@ namespace details {
             return false;
 
         assert( output.second );
+        assert( output.first >= maximum_mtu_size + l2cap_layer_header_size );
 
         l2cap_input_handler< ConnectionDetails > handler(
             this, channel_id, input + l2cap_layer_header_size, in_size - l2cap_layer_header_size,
@@ -268,6 +272,7 @@ namespace details {
             return false;
 
         assert( output.second );
+        assert( output.first >= maximum_mtu_size + l2cap_layer_header_size );
 
         l2cap_output_handler< ConnectionDetails > handler(
             this, output.second + l2cap_layer_header_size, output.first - l2cap_layer_header_size, connection );

--- a/tests/l2cap_tests.cpp
+++ b/tests/l2cap_tests.cpp
@@ -133,8 +133,11 @@ public:
             pdu.data(), pdu.size(), connection_data_ );
     }
 
-    void add_buffer( std::size_t size )
+    // provides room for one L2CAP PDU with the given payload size
+    void add_buffer( std::size_t payload_size )
     {
+        const std::size_t size = payload_size + bluetoe::details::l2cap_layer_header_size;
+
         BOOST_REQUIRE( current_buffer_used_ <= current_buffer_used_ + size );
 
         buffers_.push_back( { size, &overall_buffer_[ current_buffer_used_ ] } );
@@ -151,7 +154,7 @@ public:
 
         const auto buf = buffers_.front();
 
-        if ( buf.first < size )
+        if ( buf.first < size + bluetoe::details::l2cap_layer_header_size )
             return { 0, nullptr };
 
         buffers_.erase( buffers_.begin() );


### PR DESCRIPTION
Fixes #139.

## What the issue got wrong

I opened #139 claiming that `handle_l2cap_input()` ignores the size it was given and over reports
the writable space by four bytes. That is not true for the link layer: `allocate_l2cap_output_buffer( n )`
returns a buffer of exactly `n + 4`, because the L2CAP header lives inside what the link layer
calls the body of the PDU. So `maximum_mtu_size` on one path and `output.first - l2cap_layer_header_size`
on the other are the same number, and neither call site is wrong.

## What is actually wrong

The contract does not say whether the requested size counts the L2CAP header, and the two
implementations of it answer differently:

| implementation | on success, `first` is |
|---|---|
| `link_layer` | exactly `size + 4` |
| the mock in `tests/l2cap_tests.cpp` | the buffer's own size, only guaranteed to be at least `size` |

The tests call `add_buffer( 44 )` with a `maximum_mtu_size` of 44, so the mock hands back exactly
44 bytes while `handle_l2cap_input()` tells the channel it may write 44 bytes starting four bytes
in. That is a four byte over promise, in the test build, today. It stays invisible only because
the mock carves its buffers out of one large array, so nothing runs past a real allocation.

## The change

The contract is stated in prose, without numbers, so that it commits the link layer to nothing
about its own overhead and a non-zero size really is all the l2cap layer has to check:

> Otherwise, the returned buffer has to be large enough to take an L2CAP PDU with a payload of the
> requested size, so that a returned size that is not zero is all the l2cap layer has to check.

The arithmetic goes into an assert at the two call sites instead, where it uses only constants
that belong to the l2cap layer:

```cpp
assert( output.first >= maximum_mtu_size + l2cap_layer_header_size );
```

The call site is the right place rather than `link_layer::allocate_l2cap_output_buffer()`, because
`l2cap<>` is a template over `LinkLayer`, so the assert covers every implementation of the concept
including the test doubles. Asserting inside the link layer would only check the one implementation
that was already correct.

It earned its keep immediately: it fires on eight tests. `add_buffer()` now provides room for an
L2CAP PDU with the given payload size, which keeps the intent of every existing call, including
`add_buffer( 43 )` in the test that checks a too small buffer is refused.

## Verification

- Debug and Release on macOS, 76 of 76 test executables pass.
- The assert fails on eight l2cap tests before the mock is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
